### PR TITLE
Fixed pre-existing bugs in the ways error flows and weights and biase…

### DIFF
--- a/examples/mnist/sketch.js
+++ b/examples/mnist/sketch.js
@@ -21,7 +21,7 @@ let percent_ele;
 
 function setup() {
   createCanvas(400, 200).parent('container');
-  nn = new NeuralNetwork(784, 64, 10);
+  nn = new NeuralNetwork(784, 32, 32, 10);
   user_digit = createGraphics(200, 200);
   user_digit.pixelDensity(1);
 
@@ -169,7 +169,7 @@ function keyPressed() {
 
 
 function findMax(arr) {
-  let record = 0;
+  let record = -Infinity;
   let index = 0;
   for (let i = 0; i < arr.length; i++) {
     if (arr[i] > record) {

--- a/examples/xor/sketch.js
+++ b/examples/xor/sketch.js
@@ -34,7 +34,7 @@ function draw() {
     nn.train(data.inputs, data.outputs);
   }
 
-  nn.setLearningRate(lr_slider.value());
+  nn.learningRate = lr_slider.value();
 
   let resolution = 10;
   let cols = width / resolution;

--- a/lib/nn.js
+++ b/lib/nn.js
@@ -17,6 +17,16 @@ let tanh = new ActivationFunction(
   y => 1 - (y * y)
 );
 
+let ReLU = new ActivationFunction(
+  x => x>=0?x:0,
+  y => y>0?1:0
+);
+
+let leakyReLU = new ActivationFunction(
+  x => x>=0?x:.5*x,
+  y => y>0?1:.5
+);
+
 
 class NeuralNetwork {
   /**
@@ -100,11 +110,12 @@ class NeuralNetwork {
 
     for(let i = 0; i < this.layers.length - 1; i++) {
       let primaryNodes   = this.layers[i].nodes,
-          secondaryNodes = this.layers[i+1].nodes;
+        secondaryNodes = this.layers[i+1].nodes;
       this.connections.push({
-        weights: new Matrix(secondaryNodes, primaryNodes).randomize(),
-        bias: new Matrix(secondaryNodes, 1).randomize()
-      });
+        weights: new Matrix(secondaryNodes, primaryNodes)
+          .map(x=>(Math.random()*2-1)/Math.sqrt((primaryNodes+secondaryNodes)*0.5)),
+        bias: new Matrix(secondaryNodes, 1).map(x=>(Math.random()*2-1)/Math.sqrt(secondaryNodes))
+      }); 
     }
   }
 
@@ -133,41 +144,42 @@ class NeuralNetwork {
     if(targets.length !== this.outputsNodes) {
       throw new Error('ERROR: Target array size.');
     }
-
+    let totalError = Matrix.subtract(
+      Matrix.fromArray(targets),
+      this.outputs
+    )
+      .multiply(this.learningRate);
     // Backpropagation
     for(let i = this._outputsIndex; i > 0; i--) {
 
       if(i === this._outputsIndex) {
-
-        this.layers[i].errors = Matrix.subtract(
-          Matrix.fromArray(targets),
-          this.outputs
-        );
-
+        this.layers[i].errors = Matrix.map(
+          this.layers[i].results,
+          this.activationFunction.dfunc
+        )
+          .multiply(totalError);
       } else {
-
-        this.layers[i].errors = Matrix.multiply(
+        let previousErrors = Matrix.multiply(
           Matrix.transpose(
             this.connections[i].weights
           ),
-          this.layers[i+1].errors
-        );
+          this.layers[i+1].errors);
+          
+        this.layers[i].errors = Matrix.map(
+          this.layers[i].results,
+          this.activationFunction.dfunc
+        )
+          .multiply(previousErrors);
       }
-
-      let gradients = Matrix.map(
-        this.layers[i].results,
-        this.activationFunction.dfunc
-      )
-      .multiply(this.layers[i].errors)
-      .multiply(this.learningRate);
-
+    }
+    
+    for(let i = this._outputsIndex; i > 0; i--) {
       let deltas = Matrix.multiply(
-        gradients,
+        this.layers[i].errors,
         Matrix.transpose(i === 1 ? this.inputs : this.layers[i-1].results)
       );
-
       this.connections[i-1].weights.add(deltas);
-      this.connections[i-1].bias.add(gradients);
+      this.connections[i-1].bias.add(this.layers[i].errors);
     }
   }
 
@@ -200,7 +212,7 @@ class NeuralNetwork {
 
     let mutate = value => {
       if(Math.random() < rate) {
-        return Math.random() * 1000 - 1;
+        return Math.random() * 2 - 1;
       } else {
         return value;
       }
@@ -237,7 +249,7 @@ class NeuralNetwork {
 
   set activationFunction(func) {
 
-    if(!func instanceof ActivationFunction) {
+    if(!(func instanceof ActivationFunction)) {
       throw new Error('Activation function must be a instance of ActivationFunction.');
     }
 


### PR DESCRIPTION
…s are updated during back propagation.

The original code was wrong to treat the error as a separate entity. The
error flows backwards and is transformed by the activation functions. I
discovered this issue when testing the network against the MNIST dataset
using the ReLU activation function.

Also from a pre-existing bug, the weights and biases should be updated
after the error has been calculated.

Supporting ReLU was the motivation behind changing the way weights and
biases are initialized. Ideally, the random numbers would be taken from
a normal distribution. I'm looking for ways to take care of this simply
and under friendly licensing terms.

I also fixed a few small compatibility bugs.

I did this as a pull request to your repository because we are still discussing whether or not to include multiple layer support before moving on to TensorFlow in his videos. If he decides to leave it out we will happily direct people to your code.